### PR TITLE
Add back python-lorem, so data generation works again

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -83,6 +83,7 @@ pyrsistent==0.18.1
 pysaml2==7.1.0
 python-cinderclient==8.2.0
 python-dateutil==2.8.2
+python-lorem==1.1.2  # for generating data
 python-novaclient==17.6.0
 pytz==2021.3
 PyYAML==6.0


### PR DESCRIPTION
When moving to use `requirements.txt` in #8, I left `python-lorem` out by mistake, and it broke generating data in the image. 

Adding it back now.