### PR TITLE
Create smaller images by using multi-stage builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This image was created as a combination of other existing approaches, none of wh
 - [jeantil/openstack-swift-keystone-docker](https://github.com/jeantil/openstack-swift-keystone-docker)
 
 ## Stack
-This container is based on `debian:11.2-slim` and installs tarballs from
+This container is based on `python:3.9-slim` and installs tarballs from
 [OpenStack release Wallaby](https://docs.openstack.org/wallaby/install/).
 Furthermore, the image includes [s6-overlay](https://github.com/just-containers/s6-overlay)
 to manage processes.


### PR DESCRIPTION
I wanted to do this since creating the image, and finally it's done! 🎊

The image size went from 611MB, to 355MB, so it seems good enough, 42% smaller.

Split the building into 2 stages, installation / compilation, and configuration.

Apt commands can run in parallel, as the cache between them is not shared.