### PR TITLE
add libexpat to builder dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,8 @@ RUN         --mount=type=cache,target=/var/cache/apt,sharing=private \
                 liberasurecode-dev \
                 gcc \
                 libc6-dev \
+                libexpat1 \
+                libexpat1-dev \
         &&  apt-get autoremove -yq --purge
 
 # Install Keystone + swift + clients


### PR DESCRIPTION
### Description
Fresh builds are failing since the ring builder is lacking its required dependency `libexpat1-dev`. PR adds this to the correct build stage.

### Changes
* Install `libexpat1`, `libexpat1-dev` in stage `builder`