### PR TITLE
Change logging level to ERROR

### DIFF
--- a/docker/rootfs/etc/swift/account-server.conf
+++ b/docker/rootfs/etc/swift/account-server.conf
@@ -4,8 +4,9 @@ bind_port = 6202
 workers = 0
 mount_check = false
 log_facility = LOG_LOCAL5
+log_level = ERROR
 recon_cache_path = /var/cache/swift
-eventlet_debug = true
+eventlet_debug = false
 disable_fallocate = true
 
 [pipeline:main]

--- a/docker/rootfs/etc/swift/container-reconciler.conf
+++ b/docker/rootfs/etc/swift/container-reconciler.conf
@@ -3,8 +3,8 @@
 # user = swift
 # You can specify default log routing here if you want:
 # log_name = swift
-# log_facility = LOG_LOCAL0
-# log_level = INFO
+log_facility = LOG_LOCAL0
+log_level = ERROR
 # log_address = /dev/log
 #
 # comma separated list of functions to call to setup custom log handlers.

--- a/docker/rootfs/etc/swift/container-server.conf
+++ b/docker/rootfs/etc/swift/container-server.conf
@@ -5,8 +5,9 @@ workers = 0
 mount_check = false
 disable_fallocate = true
 log_facility = LOG_LOCAL4
+log_level = ERROR
 recon_cache_path = /var/cache/swift
-eventlet_debug = true
+eventlet_debug = false
 
 [pipeline:main]
 pipeline = healthcheck recon container-server

--- a/docker/rootfs/etc/swift/object-server.conf
+++ b/docker/rootfs/etc/swift/object-server.conf
@@ -5,7 +5,8 @@ workers = 0
 mount_check = false
 disable_fallocate = true
 log_facility = LOG_LOCAL3
-eventlet_debug = true
+log_level = ERROR
+eventlet_debug = false
 
 [pipeline:main]
 pipeline = healthcheck recon object-server

--- a/docker/rootfs/etc/swift/proxy-server.conf
+++ b/docker/rootfs/etc/swift/proxy-server.conf
@@ -5,10 +5,10 @@ workers = 0
 log_address = /dev/log
 log_facility = LOG_LOCAL2
 log_headers = false
-log_level = DEBUG
+log_level = ERROR
 log_name = proxy-server
 user = swift
-eventlet_debug = true
+eventlet_debug = false
 
 [pipeline:main]
 # pipeline = catch_errors gatekeeper healthcheck proxy-logging cache etag-quoter listing_formats bulk tempurl ratelimit s3api tempauth staticweb copy container-quotas account-quotas slo dlo versioned_writes symlink proxy-logging proxy-server


### PR DESCRIPTION
The container outputs periodic logs, which while useful for debugging the image, hinders the development experience.

This changes the logging level to ERROR, which basically makes keystone-swift output very little. Keystone API requests are still logged though.