### PR TITLE
Update broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ TempAuth
 This image also comes with S3 API enabled. To use it, generate credentials and use them to authenticate against the S3 API.
 Below is an example using the credentials with [`s3cmd`](https://github.com/s3tools/s3cmd).
 
-The swift <-> S3 compatibility has its [limitations described here](https://opendev.org/openstack/swift/src/branch/stable/wallaby/doc/source/s3_compat.rst).
+The swift <-> S3 compatibility has its [limitations described here](https://opendev.org/openstack/swift/src/branch/unmaintained/wallaby/doc/source/s3_compat.rst).
 
 1. Create credentials
 ```bash


### PR DESCRIPTION
I was testing this docker image and reading through the instructions and found a broken link. Looks like the stable branch used previously for building this image has gone unmantained or something.  